### PR TITLE
dpickett/gh68/bidirectional webpack

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -6,7 +6,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [14.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,20 +5,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.1](https://github.com/LaunchAcademy/generator-engage/releases/tag/v0.2.1)
+## [Unreleased]
 
-### Added
+## Added
 
 - added console / repl when objection is supported [#31](https://github.com/LaunchAcademy/generator-engage/issues/40)
-- `.eslintrc.json` and `.prettierrc` files for client [#40](https://github.com/LaunchAcademy/generator-engage/issues/40)
 - added `dev:debug` convenience script in server [#72](https://github.com/LaunchAcademy/generator-engage/issues/72)
 - added `--help` documentation for the `app` generator [#71](https://github.com/LaunchAcademy/generator-engage/issues/71)
 - include a global `main.scss` for global styling [#73](https://github.com/LaunchAcademy/generator-engage/issues/73)
+- support running webpack bidirectionally, handle for an allow list of client-side routes [#68](https://github.com/LaunchAcademy/generator-engage/issues/68)
+- change `index.js` to `main.js` client-side
+- specify node engine directives in all package.jsons on the basis of the generator runtime
 
 ### Changed
 
 - use `cookie-session` instead of `express-session` [#66](https://github.com/LaunchAcademy/generator-engage/issues/66)
 - changed options to adhere to camelCase conventions consistently
+- development boot and middleware configuration now takes advantage of top-level await, allowing `dotenv` and `errorhandler` to be true `devDependencies`
+
+
+## [0.2.1](https://github.com/LaunchAcademy/generator-engage/releases/tag/v0.2.1)
+
+### Added
+
+- `.eslintrc.json` and `.prettierrc` files for client [#40](https://github.com/LaunchAcademy/generator-engage/issues/40)
+
+
 
 ## [0.2.0](https://github.com/LaunchAcademy/generator-engage/releases/tag/v0.2.0)
 

--- a/__tests__/client.test.js
+++ b/__tests__/client.test.js
@@ -59,7 +59,7 @@ describe("generator-engage:client", () => {
 
     it("installs webpack-cli as a dev dependency", () => {
       json = readPackageJson();
-      expect(json.devDependencies["webpack-cli"]).toBeDefined();
+      expect(json.dependencies["webpack-cli"]).toBeDefined();
     });
 
     it("creates a public/index.html", () => {

--- a/__tests__/server.test.js
+++ b/__tests__/server.test.js
@@ -92,6 +92,11 @@ describe("generator-engage:server", () => {
       expect(json.scripts.start).toEqual("node src/app.js");
     });
 
+    it("specifies a node engine", () => {
+      json = readPackageJson();
+      expect(json.engines.node).toBeDefined();
+    });
+
     describe("nodemon", () => {
       it("installs nodemon as a dev dependency", () => {
         expect(json.devDependencies.nodemon).toBeDefined();

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -1,6 +1,7 @@
 const path = require("path");
 
 const EngageGenerator = require("../../lib/EngageGenerator");
+const getNodeVersion = require("../../lib/getNodeVersion");
 const initServerOptions = require("../server/initServerOptions");
 
 module.exports = class AppGenerator extends EngageGenerator {
@@ -26,6 +27,7 @@ module.exports = class AppGenerator extends EngageGenerator {
     ["package.json", "Procfile"].forEach((filePath) => {
       this.fs.copyTpl(this.templatePath(filePath), this.generatedPath(filePath), {
         name: path.basename(this.generatedPath()),
+        nodeVersion: getNodeVersion(),
       });
     });
   }

--- a/generators/app/templates/package.json
+++ b/generators/app/templates/package.json
@@ -14,5 +14,8 @@
     "dev:client": "yarn workspace <%= name %>-client dev",
     "heroku-postbuild": "yarn workspace <%= name %>-client build",
     "start": "yarn workspace <%= name %>-server start"
+  },
+  "engines": {
+    "node": "~<%= nodeVersion.major %>.<%= nodeVersion.minor %>"
   }
 }

--- a/generators/app/templates/package.json
+++ b/generators/app/templates/package.json
@@ -6,6 +6,9 @@
     "client"
   ],
   "scripts": {
+    "build:client": "yarn workspace run-from-server-client build",
+    "dev": "yarn workspace <%= name %>-server dev",
+    "dev:debug": "yarn workspace <%= name %>-server dev:debug",
     "dev:server:debug": "PORT=4000 yarn workspace <%= name %>-server dev:debug",
     "dev:server": "PORT=4000 yarn workspace <%= name %>-server dev",
     "dev:client": "yarn workspace <%= name %>-client dev",

--- a/generators/client/index.js
+++ b/generators/client/index.js
@@ -1,5 +1,6 @@
 const path = require("path");
 const EngageGenerator = require("../../lib/EngageGenerator");
+const getNodeVersion = require("../../lib/getNodeVersion");
 
 const reactDependencies = {
   "@babel/core": "7.10.2",
@@ -57,6 +58,7 @@ class ClientGenerator extends EngageGenerator {
       this.fs.copyTpl(this.templatePath(filePath), this.generatedPath(filePath), {
         options: this.options,
         name: path.basename(this.generatedPath("../")),
+        nodeVersion: getNodeVersion(),
       });
     });
 

--- a/generators/client/index.js
+++ b/generators/client/index.js
@@ -19,17 +19,19 @@ const reactDependencies = {
   "react-dom": "~16.13",
   "react-hot-loader": "^4.12.21",
   "react-router-dom": "~5.2",
-  "file-loader": "^6.0.0",
-  "css-loader": "^3.6.0",
+  "file-loader": "^6.2.0",
+  "html-webpack-plugin": "^4.5.0",
+  "css-loader": "^5.0.0",
   "mini-css-extract-plugin": "^0.9.0",
   "node-sass": "^4.14.1",
   "sass-loader": "^8.0.2",
   "style-loader": "^1.2.1",
+  webpack: "^5.3.2",
+  "webpack-cli": "^4.1.0",
+  "webpack-hot-middleware": "^2.25.0",
 };
 
 const reactDevDependencies = {
-  webpack: "^4.43.0",
-  "webpack-cli": "~3.3.11",
   "webpack-dev-server": "~3.11",
 };
 class ClientGenerator extends EngageGenerator {
@@ -48,6 +50,7 @@ class ClientGenerator extends EngageGenerator {
       "webpack.config.js",
       "babel.config.js",
       "public/index.html",
+      "public/index.template.html",
       "public/favicon.ico",
       ".prettierrc",
     ].forEach((filePath) => {

--- a/generators/client/templates/package.json
+++ b/generators/client/templates/package.json
@@ -6,5 +6,8 @@
   "license": "UNLICENSED",
   "private": true,
   "name": "<%= name %>-client",
-  "version": "0.0.1"
+  "version": "0.0.1",
+  "engines": {
+    "node": "~<%= nodeVersion.major %>.<%= nodeVersion.minor %>"
+  }
 }

--- a/generators/client/templates/public/index.template.html
+++ b/generators/client/templates/public/index.template.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+    <title>Engage</title>
+  </head>
+
+  <body>
+    <div id="app"></div>
+    <noscript>
+      You need to enable JavaScript to run this app.
+    </noscript>
+  </body>
+</html>

--- a/generators/client/templates/webpack.config.js
+++ b/generators/client/templates/webpack.config.js
@@ -1,18 +1,27 @@
 const path = require("path");
 const webpack = require("webpack");
 
+const HtmlWebpackPlugin = require("html-webpack-plugin");
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 
 const isDevelopment = (process.env.NODE_ENV || "development") === "development";
 
+const initialEntryPoints = isDevelopment ? ["webpack-hot-middleware/client?reload=true"] : [];
+
 module.exports = {
-  entry: ["./src/main.js"],
+  entry: [...initialEntryPoints, path.join(__dirname, "./src/main.js")],
+  context: path.resolve(__dirname),
+  devtool: isDevelopment ? "source-map" : false,
   mode: isDevelopment ? "development" : "production",
   plugins: [
     new webpack.HotModuleReplacementPlugin(),
     new MiniCssExtractPlugin({
       filename: isDevelopment ? "[name].css" : "[name].[hash].css",
       chunkFilename: isDevelopment ? "[id].css" : "[id].[hash].css",
+    }),
+    new HtmlWebpackPlugin({
+      title: "Engage",
+      template: path.join(__dirname, "public/index.template.html"),
     }),
   ],
   module: {
@@ -21,19 +30,15 @@ module.exports = {
         test: /\.(js)$/,
         exclude: /(node_modules|bower_components)/,
         loader: "babel-loader",
-        options: { presets: ["@babel/env"] },
+        options: { presets: ["@babel/env"], cwd: path.resolve(__dirname) },
       },
       {
         test: /\.(png|jpe?g|gif)$/i,
-        use: [
-          {
-            loader: "file-loader",
-          },
-        ],
+        loader: "file-loader",
       },
       {
         test: /\.module\.s(a|c)ss$/,
-        loader: [
+        use: [
           isDevelopment ? "style-loader" : MiniCssExtractPlugin.loader,
           {
             loader: "css-loader",
@@ -55,7 +60,7 @@ module.exports = {
       {
         test: /\.s(a|c)ss$/,
         exclude: /\.module.(s(a|c)ss)$/,
-        loader: [
+        use: [
           isDevelopment ? "style-loader" : MiniCssExtractPlugin.loader,
           "css-loader",
           {
@@ -76,7 +81,7 @@ module.exports = {
     extensions: ["*", ".js", ".scss"],
   },
   output: {
-    path: path.resolve(__dirname, "<%= options["outputDir"] %>"),
+    path: path.resolve(__dirname, "../server/public/dist"),
     publicPath: "/dist/",
     filename: "bundle.js",
   },

--- a/generators/server/index.js
+++ b/generators/server/index.js
@@ -5,6 +5,7 @@ const { v4: uuidv4 } = require("uuid");
 const EngageGenerator = require("../../lib/EngageGenerator");
 const insertAfter = require("../../lib/insertAfter");
 const insertBefore = require("../../lib/insertBefore.js");
+const getNodeVersion = require("../../lib/getNodeVersion");
 
 const { supportedViewEngines, supportedTestFrameworks } = require("./constants");
 const initServerOptions = require("./initServerOptions");
@@ -46,6 +47,7 @@ module.exports = class ServerGenerator extends EngageGenerator {
     this.fs.copyTpl(this.templatePath("package.json"), this.generatedPath("package.json"), {
       name: this._getName(),
       appPath: serverFileName,
+      nodeVersion: getNodeVersion(),
     });
 
     this.fs.copyTpl(this.templatePath("src/app.js"), this.generatedPath(serverFileName));

--- a/generators/server/templates/package.json
+++ b/generators/server/templates/package.json
@@ -6,5 +6,8 @@
   "private": true,
   "type": "module",
   "version": "0.0.1",
-  "name": "<%= name %>-server"
+  "name": "<%= name %>-server",
+  "engines": {
+    "node": "~<%= nodeVersion.major %>.<%= nodeVersion.minor %>"
+  }
 }

--- a/generators/server/templates/snippets/client/requires.js
+++ b/generators/server/templates/snippets/client/requires.js
@@ -1,0 +1,1 @@
+import clientRouter from "./clientRouter.js";

--- a/generators/server/templates/snippets/client/use.js
+++ b/generators/server/templates/snippets/client/use.js
@@ -1,0 +1,1 @@
+rootRouter.use("/", clientRouter);

--- a/generators/server/templates/src/app.js
+++ b/generators/server/templates/src/app.js
@@ -6,9 +6,10 @@ import { fileURLToPath } from "url";
 import "./boot.js";
 import configuration from "./config.js";
 import addMiddlewares from "./middlewares/addMiddlewares.js";
+import rootRouter from "./routes/rootRouter.js";
 
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = path.dirname(__filename)
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 const app = express();
 
@@ -20,6 +21,7 @@ app.use(bodyParser.urlencoded({ extended: true }));
 app.use(bodyParser.json());
 
 addMiddlewares(app);
+app.use(rootRouter);
 
 app.listen(configuration.web.port, configuration.web.host, () => {
   console.log("Server is listening...");

--- a/generators/server/templates/src/boot/environments/development.js
+++ b/generators/server/templates/src/boot/environments/development.js
@@ -1,7 +1,7 @@
-import dotenv from "dotenv";
 import getNodeEnv from "../../config/getNodeEnv.js";
 
 if (getNodeEnv() === "development") {
   // development specific middlewares here
-  dotenv.config();
+  const { default: dotenv } = await import("dotenv");
+  await dotenv.config();
 }

--- a/generators/server/templates/src/boot/environments/test.js
+++ b/generators/server/templates/src/boot/environments/test.js
@@ -1,7 +1,7 @@
-import dotenv from "dotenv";
 import getNodeEnv from "../../config/getNodeEnv.js";
 
 if (getNodeEnv() === "test") {
-  // test specific middlewares here
-  dotenv.config();
+  // development specific middlewares here
+  const { default: dotenv } = await import("dotenv");
+  await dotenv.config();
 }

--- a/generators/server/templates/src/middlewares/addMiddlewares.js
+++ b/generators/server/templates/src/middlewares/addMiddlewares.js
@@ -6,14 +6,14 @@ import addExpressSession from "./addExpressSession.js";
 import addDbMiddleware from "./addDbMiddleware.js";
 <% } -%>
 
-const addMiddlewares = app => {
+const addMiddlewares = async app => {
 <% if(options["sessionsEnabled"]) { -%>
   addExpressSession(app);
 <% } -%>
 <% if(options["dbClient"] === "pg") { -%>
   addDbMiddleware(app);
 <% } -%>
-  addEnvironmentMiddlewares(app);
+  await addEnvironmentMiddlewares(app);
 };
 
 export default addMiddlewares;

--- a/generators/server/templates/src/middlewares/clientMiddlewares.js
+++ b/generators/server/templates/src/middlewares/clientMiddlewares.js
@@ -1,0 +1,10 @@
+const config = await import("../config.js");
+
+export default async () => {
+  let middlewareList = [];
+  if (config.default.nodeEnv !== "production") {
+    const { default: middlewareFunc } = await import("./webpackMiddlewares.js");
+    middlewareList = middlewareFunc();
+  }
+  return middlewareList;
+};

--- a/generators/server/templates/src/middlewares/environments/addDevelopmentMiddlewares.js
+++ b/generators/server/templates/src/middlewares/environments/addDevelopmentMiddlewares.js
@@ -1,8 +1,8 @@
-import errorHandler from "../errorHandler.js";
 import config from "../../config.js";
 
-const addDevelopmentMiddlewares = app => {
+const addDevelopmentMiddlewares = async (app) => {
   if (config.nodeEnv === "development") {
+    const { default: errorHandler } = await import("../errorHandler.js");
     app.use(errorHandler());
   }
 };

--- a/generators/server/templates/src/middlewares/webpackMiddlewares.js
+++ b/generators/server/templates/src/middlewares/webpackMiddlewares.js
@@ -1,0 +1,14 @@
+import webpack from "webpack";
+import devMiddleware from "webpack-dev-middleware";
+import hotMiddleware from "webpack-hot-middleware";
+import webpackConfig from "../../../client/webpack.config.js";
+const compiler = webpack(webpackConfig);
+
+export default () => {
+  return [
+    devMiddleware(compiler, {
+      publicPath: webpackConfig.output.publicPath,
+    }),
+    hotMiddleware(compiler),
+  ];
+};

--- a/generators/server/templates/src/routes/clientRouter.js
+++ b/generators/server/templates/src/routes/clientRouter.js
@@ -1,0 +1,26 @@
+import express from "express";
+import { fileURLToPath } from "url";
+import path, { dirname } from "path";
+import clientMiddlewares from "../middlewares/clientMiddlewares.js";
+import config from "../config.js";
+
+const router = new express.Router();
+const currentPath = dirname(fileURLToPath(import.meta.url));
+
+let indexPath = path.join(currentPath, "../../public/dist/index.html");
+if (config.nodeEnv !== "production") {
+  indexPath = path.join(currentPath, "../../../client/public/index.html");
+}
+
+const clientRoutes = ["/client", "/name"];
+
+router.get(clientRoutes, (req, res) => {
+  res.sendFile(indexPath);
+});
+
+const middlewares = await clientMiddlewares();
+if (middlewares.length > 0) {
+  router.use(middlewares);
+}
+
+export default router;

--- a/generators/server/templates/src/routes/rootRouter.js
+++ b/generators/server/templates/src/routes/rootRouter.js
@@ -1,0 +1,7 @@
+import express from "express";
+
+const rootRouter = new express.Router();
+
+//place your server-side routes here
+
+export default rootRouter;

--- a/lib/getNodeVersion.js
+++ b/lib/getNodeVersion.js
@@ -1,0 +1,7 @@
+const semver = require("semver");
+
+const getNodeVersion = () => {
+  return semver.parse(process.versions.node);
+};
+
+module.exports = getNodeVersion;

--- a/lib/insertBefore.js
+++ b/lib/insertBefore.js
@@ -1,0 +1,52 @@
+const parser = require("@babel/parser");
+const traverse = require("@babel/traverse").default;
+const generate = require("@babel/generator").default;
+const prettier = require("prettier");
+
+// TODO: dry this up with insertAfter
+
+/**
+ * @typedef {import("@babel/traverse").NodePath} NodePath
+ * @typedef {import("yeoman-generator")} Generator
+ * /
+
+/**
+ * Inserts a snippet of code after a matching path
+ *
+ * @param {Generator} generator the Yeoman generator
+ * @param {*} snippetFile
+ * @param {*} destinationPath
+ * @param {MatchCallback} matchFunc
+ */
+module.exports = (generator, snippetFile, destinationPath, matchFunc) => {
+  const destinationFileContents = generator.fs.read(generator.destinationPath(destinationPath));
+  const snippetFileContents = generator.fs.read(generator.templatePath(snippetFile));
+  const tree = parser.parse(destinationFileContents, {
+    sourceType: "module",
+    plugins: ["importMeta"],
+  });
+  const newTree = parser.parse(snippetFileContents, {
+    sourceType: "module",
+    plugins: ["importMeta"],
+  });
+  let inserted = false;
+  traverse(tree, {
+    enter(path) {
+      // eslint-disable-next-line no-debugger
+      if (!inserted && matchFunc(path)) {
+        path.insertBefore(newTree);
+        inserted = true;
+      }
+    },
+  });
+  const { code } = generate(tree, {}, destinationFileContents);
+  generator.fs.write(
+    generator.destinationPath(destinationPath),
+    prettier.format(code, { parser: "babel" })
+  );
+};
+
+/**
+ * @callback MatchCallback function to determine whether code should be inserted
+ * @param {NodePath} path what is being traversed
+ */

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "@babel/traverse": "^7.8.6",
     "chalk": "^2.1.0",
     "dotenv": "^8.2.0",
-    "generator-engage": "/Users/dpickett/work/generator-engage",
     "prettier": "^2.0.5",
     "semver": "^7.3.2",
     "uuid": "^8.1.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@types/jest": "^26.0.0",
     "babel-jest": "^26.0.1",
     "coveralls": "^3.0.7",
-    "eslint": "6.8.0",
+    "eslint": "^7.12.1",
     "eslint-config-airbnb": "18.1.0",
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-import": "^2.18.2",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@babel/traverse": "^7.8.6",
     "chalk": "^2.1.0",
     "dotenv": "^8.2.0",
+    "generator-engage": "/Users/dpickett/work/generator-engage",
     "prettier": "^2.0.5",
     "uuid": "^8.1.0",
     "yeoman-generator": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "yeoman-test": "^1.7.0"
   },
   "engines": {
-    "node": ">= 12",
+    "node": ">= 14",
     "npm": ">= 4.0.0"
   },
   "dependencies": {
@@ -53,6 +53,7 @@
     "dotenv": "^8.2.0",
     "generator-engage": "/Users/dpickett/work/generator-engage",
     "prettier": "^2.0.5",
+    "semver": "^7.3.2",
     "uuid": "^8.1.0",
     "yeoman-generator": "^2.0.1",
     "yosay": "^2.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -998,6 +998,22 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
+"@eslint/eslintrc@^0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.2.1.tgz#f72069c330461a06684d119384435e12a5d76e3c"
+  integrity sha512-XRUeBZ5zBWLYgSANMpThFddrZZkEbGHgUdt5UJjZfnlN9BGCiUBrf+nvbRupSjMvqzwnQN0qwCmOxITt1cfywA==
+  dependencies:
+    ajv "^6.12.4"
+    debug "^4.1.1"
+    espree "^7.3.0"
+    globals "^12.1.0"
+    ignore "^4.0.6"
+    import-fresh "^3.2.1"
+    js-yaml "^3.13.1"
+    lodash "^4.17.19"
+    minimatch "^3.0.4"
+    strip-json-comments "^3.1.1"
+
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz#fd3db1d59ecf7cf121e80650bb86712f9b55eced"
@@ -1431,6 +1447,11 @@ acorn@^7.1.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.2.0.tgz#17ea7e40d7c8640ff54a694c889c26f31704effe"
   integrity sha512-apwXVmYVpQ34m/i71vrApRrRKCWQnZZF1+npOD0WV5xZFfwWOmKGQ2RWlfdy9vWITsenisM8M0Qeq8agcFHNiQ==
 
+acorn@^7.4.0:
+  version "7.4.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
+  integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
+
 agent-base@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-4.3.0.tgz#8165f01c436009bccad0b1d122f05ed770efc6ee"
@@ -1456,6 +1477,16 @@ ajv@^6.10.0, ajv@^6.10.2:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
+ajv@^6.12.4:
+  version "6.12.6"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
+  integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
+
 ajv@^6.5.5:
   version "6.12.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.0.tgz#06d60b96d87b8454a5adaba86e7854da629db4b7"
@@ -1465,6 +1496,11 @@ ajv@^6.5.5:
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
+
+ansi-colors@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.1.tgz#cbb9ae256bf750af1eab344f229aa27fe94ba348"
+  integrity sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==
 
 ansi-escapes@^3.0.0, ansi-escapes@^3.2.0:
   version "3.2.0"
@@ -2019,13 +2055,6 @@ cli-cursor@^2.0.0, cli-cursor@^2.1.0:
   dependencies:
     restore-cursor "^2.0.0"
 
-cli-cursor@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-3.1.0.tgz#264305a7ae490d1d03bf0c9ba7c925d1753af307"
-  integrity sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==
-  dependencies:
-    restore-cursor "^3.1.0"
-
 cli-table@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/cli-table/-/cli-table-0.3.1.tgz#f53b05266a8b1a0b934b3d0821e6e2dc5914ae23"
@@ -2259,6 +2288,15 @@ cross-spawn@^7.0.0:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
+cross-spawn@^7.0.2:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
+  integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
+  dependencies:
+    path-key "^3.1.0"
+    shebang-command "^2.0.0"
+    which "^2.0.1"
+
 cssom@^0.4.4:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.4.4.tgz#5a66cf93d2d0b661d80bf6a44fb65f5c2e4e0a10"
@@ -2373,7 +2411,7 @@ deep-extend@^0.6.0:
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
   integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
 
-deep-is@~0.1.3:
+deep-is@^0.1.3, deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
   integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
@@ -2564,6 +2602,13 @@ end-of-stream@^1.1.0:
   integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
   dependencies:
     once "^1.4.0"
+
+enquirer@^2.3.5:
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/enquirer/-/enquirer-2.3.6.tgz#2a7fe5dd634a1e4125a975ec994ff5456dc3734d"
+  integrity sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==
+  dependencies:
+    ansi-colors "^4.1.1"
 
 errlop@^2.0.0:
   version "2.0.0"
@@ -2783,18 +2828,18 @@ eslint-plugin-react@^7.19.0:
     string.prototype.matchall "^4.0.2"
     xregexp "^4.3.0"
 
-eslint-scope@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.0.0.tgz#e87c8887c73e8d1ec84f1ca591645c358bfc8fb9"
-  integrity sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==
+eslint-scope@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
+  integrity sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==
   dependencies:
-    esrecurse "^4.1.0"
+    esrecurse "^4.3.0"
     estraverse "^4.1.1"
 
-eslint-utils@^1.4.3:
-  version "1.4.3"
-  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.4.3.tgz#74fec7c54d0776b6f67e0251040b5806564e981f"
-  integrity sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==
+eslint-utils@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-2.1.0.tgz#d2de5e03424e707dc10c74068ddedae708741b27"
+  integrity sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==
   dependencies:
     eslint-visitor-keys "^1.1.0"
 
@@ -2803,22 +2848,34 @@ eslint-visitor-keys@^1.1.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz#e2a82cea84ff246ad6fb57f9bde5b46621459ec2"
   integrity sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==
 
-eslint@6.8.0:
-  version "6.8.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-6.8.0.tgz#62262d6729739f9275723824302fb227c8c93ffb"
-  integrity sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==
+eslint-visitor-keys@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz#30ebd1ef7c2fdff01c3a4f151044af25fab0523e"
+  integrity sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==
+
+eslint-visitor-keys@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz#21fdc8fbcd9c795cc0321f0563702095751511a8"
+  integrity sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==
+
+eslint@^7.12.1:
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.12.1.tgz#bd9a81fa67a6cfd51656cdb88812ce49ccec5801"
+  integrity sha512-HlMTEdr/LicJfN08LB3nM1rRYliDXOmfoO4vj39xN6BLpFzF00hbwBoqHk8UcJ2M/3nlARZWy/mslvGEuZFvsg==
   dependencies:
     "@babel/code-frame" "^7.0.0"
+    "@eslint/eslintrc" "^0.2.1"
     ajv "^6.10.0"
-    chalk "^2.1.0"
-    cross-spawn "^6.0.5"
+    chalk "^4.0.0"
+    cross-spawn "^7.0.2"
     debug "^4.0.1"
     doctrine "^3.0.0"
-    eslint-scope "^5.0.0"
-    eslint-utils "^1.4.3"
-    eslint-visitor-keys "^1.1.0"
-    espree "^6.1.2"
-    esquery "^1.0.1"
+    enquirer "^2.3.5"
+    eslint-scope "^5.1.1"
+    eslint-utils "^2.1.0"
+    eslint-visitor-keys "^2.0.0"
+    espree "^7.3.0"
+    esquery "^1.2.0"
     esutils "^2.0.2"
     file-entry-cache "^5.0.1"
     functional-red-black-tree "^1.0.1"
@@ -2827,54 +2884,52 @@ eslint@6.8.0:
     ignore "^4.0.6"
     import-fresh "^3.0.0"
     imurmurhash "^0.1.4"
-    inquirer "^7.0.0"
     is-glob "^4.0.0"
     js-yaml "^3.13.1"
     json-stable-stringify-without-jsonify "^1.0.1"
-    levn "^0.3.0"
-    lodash "^4.17.14"
+    levn "^0.4.1"
+    lodash "^4.17.19"
     minimatch "^3.0.4"
-    mkdirp "^0.5.1"
     natural-compare "^1.4.0"
-    optionator "^0.8.3"
+    optionator "^0.9.1"
     progress "^2.0.0"
-    regexpp "^2.0.1"
-    semver "^6.1.2"
-    strip-ansi "^5.2.0"
-    strip-json-comments "^3.0.1"
+    regexpp "^3.1.0"
+    semver "^7.2.1"
+    strip-ansi "^6.0.0"
+    strip-json-comments "^3.1.0"
     table "^5.2.3"
     text-table "^0.2.0"
     v8-compile-cache "^2.0.3"
 
-espree@^6.1.2:
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-6.2.1.tgz#77fc72e1fd744a2052c20f38a5b575832e82734a"
-  integrity sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==
+espree@^7.3.0:
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-7.3.0.tgz#dc30437cf67947cf576121ebd780f15eeac72348"
+  integrity sha512-dksIWsvKCixn1yrEXO8UosNSxaDoSYpq9reEjZSbHLpT5hpaCAKTLBwq0RHtLrIr+c0ByiYzWT8KTMRzoRCNlw==
   dependencies:
-    acorn "^7.1.1"
+    acorn "^7.4.0"
     acorn-jsx "^5.2.0"
-    eslint-visitor-keys "^1.1.0"
+    eslint-visitor-keys "^1.3.0"
 
 esprima@^4.0.0, esprima@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
 
-esquery@^1.0.1:
+esquery@^1.2.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.3.1.tgz#b78b5828aa8e214e29fb74c4d5b752e1c033da57"
   integrity sha512-olpvt9QG0vniUBZspVRN6lwB7hOZoTRtT+jzR+tS4ffYx2mzbw+z0XCOk44aaLYKApNX5nMm+E+P6o25ip/DHQ==
   dependencies:
     estraverse "^5.1.0"
 
-esrecurse@^4.1.0:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.2.1.tgz#007a3b9fdbc2b3bb87e4879ea19c92fdbd3942cf"
-  integrity sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==
+esrecurse@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.3.0.tgz#7ad7964d679abb28bee72cec63758b1c5d2c9921"
+  integrity sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==
   dependencies:
-    estraverse "^4.1.0"
+    estraverse "^5.2.0"
 
-estraverse@^4.1.0, estraverse@^4.1.1, estraverse@^4.2.0:
+estraverse@^4.1.1, estraverse@^4.2.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.3.0.tgz#398ad3f3c5a24948be7725e83d11a7de28cdbd1d"
   integrity sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
@@ -2883,6 +2938,11 @@ estraverse@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.1.0.tgz#374309d39fd935ae500e7b92e8a6b4c720e59642"
   integrity sha512-FyohXK+R0vE+y1nHLoBM7ZTyqRpqAlhdZHCWIWEviFLiGB8b04H6bQs8G+XTthacvT8VuwvteiP7RJSxMs8UEw==
+
+estraverse@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.2.0.tgz#307df42547e6cc7324d3cf03c155d5cdb8c53880"
+  integrity sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==
 
 esutils@^2.0.2:
   version "2.0.3"
@@ -3083,7 +3143,7 @@ fast-json-stable-stringify@^2.0.0:
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
 
-fast-levenshtein@~2.0.6:
+fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
@@ -3114,13 +3174,6 @@ figures@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-2.0.0.tgz#3ab1a2d2a62c8bfb431a0c94cb797a2fce27c962"
   integrity sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=
-  dependencies:
-    escape-string-regexp "^1.0.5"
-
-figures@^3.0.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/figures/-/figures-3.2.0.tgz#625c18bd293c604dc4a8ddb2febf0c88341746af"
-  integrity sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==
   dependencies:
     escape-string-regexp "^1.0.5"
 
@@ -3230,7 +3283,7 @@ functional-red-black-tree@^1.0.1:
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
 
-generator-engage@/Users/dpickett/work/generator-engage:
+"generator-engage@file:.":
   version "0.2.1"
   dependencies:
     "@babel/generator" "^7.8.6"
@@ -3238,6 +3291,7 @@ generator-engage@/Users/dpickett/work/generator-engage:
     "@babel/traverse" "^7.8.6"
     chalk "^2.1.0"
     dotenv "^8.2.0"
+    generator-engage "file:."
     prettier "^2.0.5"
     uuid "^8.1.0"
     yeoman-generator "^2.0.1"
@@ -3627,7 +3681,7 @@ import-fresh@^2.0.0:
     caller-path "^2.0.0"
     resolve-from "^3.0.0"
 
-import-fresh@^3.0.0:
+import-fresh@^3.0.0, import-fresh@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.2.1.tgz#633ff618506e793af5ac91bf48b72677e15cbe66"
   integrity sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==
@@ -3707,25 +3761,6 @@ inquirer@^6.0.0:
     rxjs "^6.4.0"
     string-width "^2.1.0"
     strip-ansi "^5.1.0"
-    through "^2.3.6"
-
-inquirer@^7.0.0:
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-7.1.0.tgz#1298a01859883e17c7264b82870ae1034f92dd29"
-  integrity sha512-5fJMWEmikSYu0nv/flMc475MhGbB7TSPd/2IpFV4I4rMklboCH2rQjYY5kKiYGHqUF9gvaambupcJFFG9dvReg==
-  dependencies:
-    ansi-escapes "^4.2.1"
-    chalk "^3.0.0"
-    cli-cursor "^3.1.0"
-    cli-width "^2.0.0"
-    external-editor "^3.0.3"
-    figures "^3.0.0"
-    lodash "^4.17.15"
-    mute-stream "0.0.8"
-    run-async "^2.4.0"
-    rxjs "^6.5.3"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
     through "^2.3.6"
 
 install-peerdeps@^2.0.1:
@@ -4678,7 +4713,15 @@ levenary@^1.1.1:
   dependencies:
     leven "^3.1.0"
 
-levn@^0.3.0, levn@~0.3.0:
+levn@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/levn/-/levn-0.4.1.tgz#ae4562c007473b932a6200d403268dd2fffc6ade"
+  integrity sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==
+  dependencies:
+    prelude-ls "^1.2.1"
+    type-check "~0.4.0"
+
+levn@~0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee"
   integrity sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=
@@ -4804,6 +4847,11 @@ lodash@^4.17.10, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17
   version "4.17.19"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
   integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
+
+lodash@^4.17.19:
+  version "4.17.20"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
+  integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
 
 log-driver@^1.2.7:
   version "1.2.7"
@@ -5077,7 +5125,7 @@ mute-stream@0.0.7:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
   integrity sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=
 
-mute-stream@0.0.8, mute-stream@~0.0.4:
+mute-stream@~0.0.4:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
@@ -5319,7 +5367,7 @@ opencollective-postinstall@^2.0.2:
   resolved "https://registry.yarnpkg.com/opencollective-postinstall/-/opencollective-postinstall-2.0.2.tgz#5657f1bede69b6e33a45939b061eb53d3c6c3a89"
   integrity sha512-pVOEP16TrAO2/fjej1IdOyupJY8KDUM1CvsaScRbw6oddvpQoOfGk4ywha0HKKVAD6RkW4x6Q+tNBwhf3Bgpuw==
 
-optionator@^0.8.1, optionator@^0.8.3:
+optionator@^0.8.1:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.3.tgz#84fa1d036fe9d3c7e21d99884b601167ec8fb495"
   integrity sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==
@@ -5330,6 +5378,18 @@ optionator@^0.8.1, optionator@^0.8.3:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
     word-wrap "~1.2.3"
+
+optionator@^0.9.1:
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.9.1.tgz#4f236a6373dae0566a6d43e1326674f50c291499"
+  integrity sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==
+  dependencies:
+    deep-is "^0.1.3"
+    fast-levenshtein "^2.0.6"
+    levn "^0.4.1"
+    prelude-ls "^1.2.1"
+    type-check "^0.4.0"
+    word-wrap "^1.2.3"
 
 os-tmpdir@~1.0.2:
   version "1.0.2"
@@ -5598,6 +5658,11 @@ posix-character-classes@^0.1.0:
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
   integrity sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=
 
+prelude-ls@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
+  integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
+
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
@@ -5852,10 +5917,10 @@ regexp.prototype.flags@^1.3.0:
     define-properties "^1.1.3"
     es-abstract "^1.17.0-next.1"
 
-regexpp@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-2.0.1.tgz#8d19d31cf632482b589049f8281f93dbcba4d07f"
-  integrity sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==
+regexpp@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.1.0.tgz#206d0ad0a5648cffbdb8ae46438f3dc51c9f78e2"
+  integrity sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==
 
 regexpu-core@^4.7.0:
   version "4.7.0"
@@ -6007,14 +6072,6 @@ restore-cursor@^2.0.0:
     onetime "^2.0.0"
     signal-exit "^3.0.2"
 
-restore-cursor@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-3.1.0.tgz#39f67c54b3a7a58cea5236d95cf0034239631f7e"
-  integrity sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==
-  dependencies:
-    onetime "^5.1.0"
-    signal-exit "^3.0.2"
-
 ret@~0.1.10:
   version "0.1.15"
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
@@ -6058,7 +6115,7 @@ run-async@^2.0.0:
   dependencies:
     is-promise "^2.1.0"
 
-run-async@^2.2.0, run-async@^2.4.0:
+run-async@^2.2.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.4.1.tgz#8440eccf99ea3e70bd409d49aab88e10c189a455"
   integrity sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==
@@ -6087,7 +6144,7 @@ rxjs@^6.3.3:
   dependencies:
     tslib "^1.9.0"
 
-rxjs@^6.4.0, rxjs@^6.5.3:
+rxjs@^6.4.0:
   version "6.5.5"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.5.5.tgz#c5c884e3094c8cfee31bf27eb87e54ccfc87f9ec"
   integrity sha512-WfQI+1gohdf0Dai/Bbmk5L5ItH5tYqm3ki2c5GdWhKjalzjg93N3avFjVStyZZz+A2Em+ZxKH5bNghw9UeylGQ==
@@ -6163,7 +6220,7 @@ semver@7.0.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.0.0.tgz#5f3ca35761e47e05b206c6daff2cf814f0316b8e"
   integrity sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==
 
-semver@^6.0.0, semver@^6.1.2, semver@^6.3.0:
+semver@^6.0.0, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
@@ -6539,7 +6596,7 @@ strip-ansi@^4.0.0:
   dependencies:
     ansi-regex "^3.0.0"
 
-strip-ansi@^5.1.0, strip-ansi@^5.2.0:
+strip-ansi@^5.1.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
@@ -6588,10 +6645,10 @@ strip-final-newline@^2.0.0:
   resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-2.0.0.tgz#89b852fb2fcbe936f6f4b3187afb0a12c1ab58ad"
   integrity sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==
 
-strip-json-comments@^3.0.1:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.0.tgz#7638d31422129ecf4457440009fba03f9f9ac180"
-  integrity sha512-e6/d0eBu7gHtdCqFt0xJr642LdToM5/cN4Qb9DbHjVx1CP5RyeM+zH7pbecEmDv/lBqb0QH+6Uqq75rxFPkM0w==
+strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
+  integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
 supports-color@^2.0.0:
   version "2.0.0"
@@ -6800,6 +6857,13 @@ tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
   integrity sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=
+
+type-check@^0.4.0, type-check@~0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.4.0.tgz#07b8203bfa7056c0657050e3ccd2c37730bab8f1"
+  integrity sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==
+  dependencies:
+    prelude-ls "^1.2.1"
 
 type-check@~0.3.2:
   version "0.3.2"
@@ -7075,7 +7139,7 @@ which@^2.0.1, which@^2.0.2:
   dependencies:
     isexe "^2.0.0"
 
-word-wrap@~1.2.3:
+word-wrap@^1.2.3, word-wrap@~1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
   integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3230,6 +3230,19 @@ functional-red-black-tree@^1.0.1:
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
 
+generator-engage@/Users/dpickett/work/generator-engage:
+  version "0.2.1"
+  dependencies:
+    "@babel/generator" "^7.8.6"
+    "@babel/parser" "^7.8.6"
+    "@babel/traverse" "^7.8.6"
+    chalk "^2.1.0"
+    dotenv "^8.2.0"
+    prettier "^2.0.5"
+    uuid "^8.1.0"
+    yeoman-generator "^2.0.1"
+    yosay "^2.0.1"
+
 gensync@^1.0.0-beta.1:
   version "1.0.0-beta.1"
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.1.tgz#58f4361ff987e5ff6e1e7a210827aa371eaac269"


### PR DESCRIPTION
fixees #68 

- working version of bidirectional webpack
- upgrade eslint
- webpack-cli is a runtime dependency
- take advantage of top level await
- specify engine on the basis of run time node version
