### PR TITLE
update default User server validation for ajv

### DIFF
--- a/generators/server/templates/src/models/User.js
+++ b/generators/server/templates/src/models/User.js
@@ -27,9 +27,8 @@ class User extends uniqueFunc(Model) {
     return {
       type: "object",
       required: ["email"],
-
       properties: {
-        email: { type: "string", format: "email" },
+        email: { type: "string", pattern: "^\\S+@\\S+\\.\\S+$" },
         cryptedPassword: { type: "string" },
       },
     };


### PR DESCRIPTION
Issue: https://github.com/LaunchAcademy/generator-engage/issues/166

Resolution: update jsonSchema validation to use `pattern` for regex instead of `format: email` 