### PR TITLE
update auth handling to avoid blank pages

### DIFF
--- a/generators/client/templates/src/components/authentication/AuthenticatedRoute.js
+++ b/generators/client/templates/src/components/authentication/AuthenticatedRoute.js
@@ -2,8 +2,11 @@ import React from "react";
 import { Redirect, Route } from "react-router";
 
 const AuthenticationCheck = ({ component: Component, user }) => {
+  if (user === undefined) {
+    return <div>Loading...</div>
+  }
   if (user !== null) {
-    return <Component />;
+    return <Component user={user} />;
   }
   return <Redirect to="/user-sessions/new" />;
 };

--- a/generators/server/templates/src/routes/clientRouter.js
+++ b/generators/server/templates/src/routes/clientRouter.js
@@ -5,6 +5,16 @@ const router = new express.Router();
 
 <% if(options["authentication"] === "passport") { -%>
 const clientRoutes = ["/", "/user-sessions/new", "/users/new"];
+const authedClientRoutes = ["/profile"];
+
+router.get(authedClientRoutes, (req, res) => {
+  if (req.user) {
+    res.sendFile(getClientIndexPath());
+  } else {
+    res.redirect("/user-sessions/new")
+  }
+});
+
 <% } else { -%>
 const clientRoutes = ["/client", "/name"];
 <% } -%>


### PR DESCRIPTION
Issue: https://github.com/LaunchAcademy/generator-engage/issues/159

Resolution:
React
- add check for when getCurrentUser fetch hasn't resolved (user is undefined) show a loading page (so that the actual component doesn't render)

Backend
- add "authedRoutes" array, and handle redirect if req.user is not present